### PR TITLE
Handle unregistered characters

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -42,3 +42,7 @@ test('test non-existing font', () => {
     index('foo', { font: 'bar' });
   }).toThrow();
 });
+
+test('test printable, but unregistered character', () => {
+  expect(index('‐')).toBe(50);
+});

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,9 @@ const getWidth = (string, settings) => {
     if (/[\x00-\x1F]/.test(char)) { // non-printable character
       return true;
     }
-    const width = widthsMap[font][char][variant];
+    // use width of 'x' as fallback for unregistered char
+    const widths = widthsMap[font][char] || widthsMap[font].x;
+    const width = widths[variant];
     totalWidth += width;
     return true;
   });


### PR DESCRIPTION
Hi, appearance of unregistered character, for example a hyphen (`‐`), in a string, would cause the library to fail. This commit fixes this by using 'x' character as fallback for such cases.